### PR TITLE
Adds a category to UIApplication so it keeps track of whether it's ap…

### DIFF
--- a/ThunderBasics.xcodeproj/project.pbxproj
+++ b/ThunderBasics.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		B1B6CF911C4E480600CDC978 /* TSCUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = B1B6CF8F1C4E480600CDC978 /* TSCUserDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1B6CF921C4E480600CDC978 /* TSCUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B6CF901C4E480600CDC978 /* TSCUserDefaults.m */; };
 		B1B6CFA81C4E5BC300CDC978 /* TSCDesignableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B6CFA71C4E5BC300CDC978 /* TSCDesignableView.swift */; };
+		B1D791FC1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = B1D791FA1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.h */; };
+		B1D791FD1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = B1D791FB1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.m */; };
 		B1DEA8DD1ABC579C008FBF59 /* NSDateFormatter+TSCDateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = B1DEA8DB1ABC579C008FBF59 /* NSDateFormatter+TSCDateFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1DEA8DE1ABC579C008FBF59 /* NSDateFormatter+TSCDateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B1DEA8DC1ABC579C008FBF59 /* NSDateFormatter+TSCDateFormatter.m */; };
 		B1E3C5DC1B626DE5005CC1C1 /* TSCSingleRequestLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B1E3C5DA1B626DE5005CC1C1 /* TSCSingleRequestLocationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -168,6 +170,8 @@
 		B1B6CF8F1C4E480600CDC978 /* TSCUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSCUserDefaults.h; sourceTree = "<group>"; };
 		B1B6CF901C4E480600CDC978 /* TSCUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSCUserDefaults.m; sourceTree = "<group>"; };
 		B1B6CFA71C4E5BC300CDC978 /* TSCDesignableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TSCDesignableView.swift; sourceTree = "<group>"; };
+		B1D791FA1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIApplication+NetworkActivityIndicator.h"; sourceTree = "<group>"; };
+		B1D791FB1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+NetworkActivityIndicator.m"; sourceTree = "<group>"; };
 		B1DEA8DB1ABC579C008FBF59 /* NSDateFormatter+TSCDateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDateFormatter+TSCDateFormatter.h"; sourceTree = "<group>"; };
 		B1DEA8DC1ABC579C008FBF59 /* NSDateFormatter+TSCDateFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+TSCDateFormatter.m"; sourceTree = "<group>"; };
 		B1E3C5DA1B626DE5005CC1C1 /* TSCSingleRequestLocationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSCSingleRequestLocationManager.h; sourceTree = "<group>"; };
@@ -314,6 +318,8 @@
 				49CF134A1AB6DEC900AA5971 /* NSString+TSCEncoding.m */,
 				36401E281BF238FC00E06E14 /* TSCDismissSegue.h */,
 				36401E291BF238FC00E06E14 /* TSCDismissSegue.m */,
+				B1D791FA1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.h */,
+				B1D791FB1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -601,6 +607,7 @@
 				B120905D1BBABEAF00AAB2E9 /* TSCCoreSpotlightIndexItem.h in Headers */,
 				C272EFF219C8325D004BD339 /* TSCGraphPoint.h in Headers */,
 				36401E2A1BF238FC00E06E14 /* TSCDismissSegue.h in Headers */,
+				B1D791FC1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.h in Headers */,
 				B1B6CF7F1C4E473B00CDC978 /* CAGradientLayer+AutoGradient.h in Headers */,
 				C272EFE619C8325D004BD339 /* NSJSONSerialization+TSCJSONSerialization.h in Headers */,
 				C272EFFE19C8325D004BD339 /* TSCWebViewController.h in Headers */,
@@ -747,6 +754,7 @@
 				49CF133B1AB6D8FC00AA5971 /* TSCToastView.m in Sources */,
 				49CF13481AB6DE9900AA5971 /* UIView+TSCView.m in Sources */,
 				C272EFE719C8325D004BD339 /* NSJSONSerialization+TSCJSONSerialization.m in Sources */,
+				B1D791FD1CBD58BA00EE5D45 /* UIApplication+NetworkActivityIndicator.m in Sources */,
 				C272EFE519C8325D004BD339 /* NSDictionary+TSCDictionary.m in Sources */,
 				B1B6CF921C4E480600CDC978 /* TSCUserDefaults.m in Sources */,
 				C272EFEA19C8325D004BD339 /* TSCAlertAction.m in Sources */,

--- a/ThunderBasics/UIApplication+NetworkActivityIndicator.h
+++ b/ThunderBasics/UIApplication+NetworkActivityIndicator.h
@@ -1,0 +1,13 @@
+//
+//  NSApplication+NetworkActivityIndicator.h
+//  ThunderBasics
+//
+//  Created by Simon Mitchell on 12/04/2016.
+//  Copyright © 2016 threesidedcube. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIApplication (NetworkActivityIndicator)
+
+@end

--- a/ThunderBasics/UIApplication+NetworkActivityIndicator.m
+++ b/ThunderBasics/UIApplication+NetworkActivityIndicator.m
@@ -1,0 +1,75 @@
+//
+//  NSApplication+NetworkActivityIndicator.m
+//  ThunderBasics
+//
+//  Created by Simon Mitchell on 12/04/2016.
+//  Copyright © 2016 threesidedcube. All rights reserved.
+//
+
+#import "UIApplication+NetworkActivityIndicator.h"
+#import <objc/runtime.h>
+
+static NSInteger activityCount = 0;
+
+@implementation UIApplication (NetworkActivityIndicator)
+
++ (void)load {
+    
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(setNetworkActivityIndicatorVisible:);
+        SEL swizzledSelector = @selector(tsc_setNetworkActivityIndicatorVisible:);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        BOOL didAddMethod =
+        class_addMethod(class,
+                        originalSelector,
+                        method_getImplementation(swizzledMethod),
+                        method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+#pragma mark - Method Swizzling
+
+- (void)tsc_setNetworkActivityIndicatorVisible:(BOOL)visible {
+    
+    if ([self isStatusBarHidden]) return;
+    
+    // Synchronise self to avoid threading issues
+    @synchronized (self) {
+    
+        // If trying to make visible
+        if (visible) {
+            
+            if (activityCount == 0) {
+                [self tsc_setNetworkActivityIndicatorVisible:YES];
+            }
+            activityCount++;
+            
+        } else { // Otherwise trying to hide it
+            
+            activityCount--;
+            if (activityCount <= 0) {
+                [self tsc_setNetworkActivityIndicatorVisible:NO];
+                activityCount=0;
+            }
+        }
+    }
+    
+}
+
+@end


### PR DESCRIPTION
…plication network activity indicator should be set to on or off

This category swizzles the setNetworkActivityIndicatorVisible. Which is something that is arguably frowned upon, however is the only way of providing this functionality to any framework which uses setNetworkActivityIndicatorVisible, once imported any framework that uses that call, will be kept in check by a local static count of the times it has been turned on/off.

It's also important to note, other frameworks also swizzle methods on UIApplication, notably Instabug which swizzles it to track any NSEvents for analytics
