### PR TITLE
Removes (Nearly all) legacy ABAddressBook references

### DIFF
--- a/ThunderBasics/TSCContactsController.h
+++ b/ThunderBasics/TSCContactsController.h
@@ -57,52 +57,24 @@ typedef void (^TSCAllContactsCompletion)(NSArray <TSCPerson *> *people, NSError 
 - (void)presentPeoplePickerWithCompletion:(TSCPeoplePickerPersonSelectedCompletion)completion inViewController:(UIViewController *)presentingViewController;
 
 /**
- Generates a `TSCPerson` object for the given NSNumber
- @param number The number that references a record ID in the users contacts
- @return `RCHPerson` filled with contact information
- */
-- (TSCPerson *)personWithRecordNumber:(NSNumber *)number __attribute((deprecated("Please use -personWithRecordIdentifier: instead")));
-
-/**
- Generates a `TSCPerson` object for the given `ABRecordID`
- @param identifier The `ABRecordID` that references a person in the users contacts
- @return `TSCPerson` filled with contact information
- */
-- (TSCPerson *)personWithRecordID:(ABRecordID)identifier;
-
-/**
- Generated a `TSCPerson` object for the record reference
- @param ref The `ABRecordRef` to convert into a `TSCPerson`
- @return `TSCPerson` filled with contact information
- */
-- (TSCPerson *)personWithRecordRef:(ABRecordRef)ref;
-
-/**
  Generates a `TSCPerson` object for the given identifier
- @param identifier The `NSString` (Contacts Framework) or `NSNumber` (ABAdressBookRef) to convert into a `TSCPerson`
+ @param identifier The `NSString` identifier of the `CNContact` to convert into a `TSCPerson`
  @return `TSCPerson` filled with contact information
 */
-- (TSCPerson *)personWithRecordIdentifier:(id)identifier;
+- (TSCPerson *)personWithRecordIdentifier:(NSString *)identifier;
 
-/**
- Converts a `NSNumber` to a `ABRecordID`
- @param number The number to convert
- @return `ABRecordID` from the NSNumber
-*/
-- (ABRecordID)recordIDForNumber:(NSNumber *)number;
-
-/**
- Converts a `ABRecordID` into a `ABRecordRef`
- @param recordID The `ABRecordID` to look up in the address book and extract a contact for
- @return An `ABRecordRef` representation of the record ID
- */
-- (ABRecordRef)recordRefForRecordID:(ABRecordID)recordID;
 
 /**
  Returns the CNContact object for a certain identifier
- @param identifier Either an NSString (Contacts Framework) or NSNumber (ABAddressBook Framework) identifying the contact
+ @param identifier The `NSString` identifier of the `CNContact` to convert into a `TSCPerson`
  */
-- (CNContact *)contactForIdentifier:(id)identifier;
+- (CNContact *)contactForIdentifier:(NSString *)identifier;
+
+/**
+ If you have a legacy contact from ABAddressBook you can use this to retrieve your contact
+ @param identifier Either an `NSString` identifier (CNContacts) or `NSNumber` identifier for the contact (ABAddressBook)
+ */
+- (CNContact *)contactForLegacyIdentifier:(id)identifier;
 
 /**
  Extracts all people from all address book sources
@@ -110,47 +82,22 @@ typedef void (^TSCAllContactsCompletion)(NSArray <TSCPerson *> *people, NSError 
  */
 - (void)extractAllContactsWithCompletion:(TSCAllContactsCompletion)completion;
 
+
 /**
- Generates a `ABPersonViewController` for presenting a contact in the address book.
+ Generates a `CNContactViewController` for presenting a contact in the address book.
  @param number The number of the record to display in the view controller
  @return A view controller that can be pushed or presented to show the user in the address book
  */
-- (ABPersonViewController *)personViewControllerForRecordNumber:(NSNumber *)number __attribute((deprecated("Please use -personViewControllerForRecordIdentifier: instead")));
+- (CNContactViewController *)personViewControllerForRecordIdentifier:(NSString *)identifier;
 
-/**
- Generates a `UIViewController` for presenting a contact in the address book.
- @param number The number of the record to display in the view controller
- @return A view controller (Either ABPersonViewController or CNContactViewController) that can be pushed or presented to show the user in the address book
- */
-- (UIViewController *)personViewControllerForRecordIdentifier:(id)identifier;
-
-/**
- Generates a `ABPersonViewController` for presenting a contact in the address book.
- @param recordID The recordID of the record to display in the view controller
- @return A view controller that can be pushed or presented to show the user in the address book
- */
-- (ABPersonViewController *)personViewControllerForRecordID:(ABRecordID)recordID;
-
-/**
- Presents an address book view for a record number
- @param number The `NSNumber` for the person that needs to be displayed to the user
- @param viewController The view controller that wishes to present the picker
- **/
-- (void)presentPersonWithRecordNumber:(NSNumber *)number inViewController:(UIViewController *)viewController __attribute((deprecated("Please use -presentPersonWithRecordIdentifier:inViewController instead")));
 
 /**
  Presents an address book view for a record id
  @param identifier The identifier for the person that needs to be displayed to the user
  @param viewController The view controller that wishes to present the picker
  **/
-- (void)presentPersonWithRecordIdentifier:(id)identifier inViewController:(UIViewController *)viewController;
+- (void)presentPersonWithRecordIdentifier:(NSString *)identifier inViewController:(UIViewController *)viewController;
 
-/**
- Presents an address book view for a record ID
- @param recordID The ABRecordID for the person that needs to be displayed to the user
- @param viewController The view controller that wishes to present the picker
- **/
-- (void)presentPersonwithRecordID:(ABRecordID)recordID inViewController:(UIViewController *)viewController;
 
 /**
  Extracts an array of TSCPerson objects for the provided identifiers
@@ -164,6 +111,6 @@ typedef void (^TSCAllContactsCompletion)(NSArray <TSCPerson *> *people, NSError 
  @param people An array of `TSCPeople` objects
  @return An array of NSNumbers that identify contacts in the addressbook database
  */
-- (NSArray <NSNumber *> *)addressbookIdsforPeople:(NSArray <TSCPerson *> *)people;
+- (NSArray <NSString *> *)addressbookIdsforPeople:(NSArray <TSCPerson *> *)people;
 
 @end

--- a/ThunderBasics/TSCContactsController.m
+++ b/ThunderBasics/TSCContactsController.m
@@ -9,12 +9,9 @@
 #import "TSCContactsController.h"
 #import "TSCPerson.h"
 
-@interface TSCContactsController () <ABPeoplePickerNavigationControllerDelegate, ABPersonViewControllerDelegate, CNContactPickerDelegate>
+@interface TSCContactsController () <CNContactPickerDelegate>
 
 @property (nonatomic, strong) UINavigationController *presentedPersonViewController;
-@property (nonatomic, assign) ABAddressBookRef addressBook;
-@property (nonatomic, strong, readwrite) dispatch_queue_t addressBookQueue;
-@property (nonatomic, strong, readwrite) dispatch_queue_t externalAddressBookQueue;
 
 @property (nonatomic, strong) id <NSObject> contactObserver;
 
@@ -40,289 +37,76 @@ static TSCContactsController *sharedController = nil;
     self = [super init];
     if (self) {
         
-        if (!NSStringFromClass([CNContact class])) {
-            
-            self.addressBookQueue = dispatch_queue_create([@"TSCContactsControllerQueue for TSCContactsController" UTF8String], DISPATCH_QUEUE_SERIAL);
-            self.externalAddressBookQueue = dispatch_queue_create([@"TSCContactsControllerQueue external for TSCContactsController" UTF8String], DISPATCH_QUEUE_SERIAL);
-        } else {
-            
-            self.contactObserver = [[NSNotificationCenter defaultCenter] addObserverForName:CNContactStoreDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
-                [[NSNotificationCenter defaultCenter] postNotificationName:TSCAddressBookChangeNotification object:nil];
-            }];
-        }
+        self.contactObserver = [[NSNotificationCenter defaultCenter] addObserverForName:CNContactStoreDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:TSCAddressBookChangeNotification object:nil];
+        }];
     }
     return self;
-}
-
-- (ABAddressBookRef)addressBook
-{
-    if (!_addressBook) {
-        
-        dispatch_sync(self.externalAddressBookQueue, ^{
-            
-            ABAddressBookRef dummyExternalAddressBook = ABAddressBookCreateWithOptions(NULL, NULL);
-            ABAddressBookRegisterExternalChangeCallback(dummyExternalAddressBook, TSCAddressBookInternalChangeCallback, (__bridge void *)(self)); // Create a dummy external address book which recieves notifications because it is external to the one we will actuall be using.
-        });
-        
-        _addressBook = ABAddressBookCreateWithOptions(NULL, NULL);
-        ABAddressBookRegisterExternalChangeCallback(_addressBook, TSCAddressBookExternalChangeCallback, (__bridge void *)(self)); // This listens out for changes made in the contacts app.
-    }
-    return _addressBook;
 }
 
 - (void)presentPeoplePickerWithCompletion:(TSCPeoplePickerPersonSelectedCompletion)completion inViewController:(UIViewController *)presentingViewController
 {
     self.TSCPeoplePickerPersonSelectedCompletion = completion;
     
-    if (NSStringFromClass([CNContactPickerViewController class])) {
+    CNContactPickerViewController *contactViewController = [CNContactPickerViewController new];
+    contactViewController.delegate = self;
+    
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         
-        CNContactPickerViewController *contactViewController = [CNContactPickerViewController new];
-        contactViewController.delegate = self;
-        
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            
-            presentingViewController.modalPresentationStyle = UIModalPresentationFormSheet;
-            contactViewController.modalPresentationStyle = UIModalPresentationFormSheet;
-        }
-        [presentingViewController presentViewController:contactViewController animated:true completion:nil];
-        
-    } else {
-     
-        dispatch_sync(self.addressBookQueue, ^{
-            
-            //Request access
-            ABAddressBookRequestAccessWithCompletion(self.addressBook, ^(bool granted, CFErrorRef error) {
-                
-                if (error) {
-                    
-                    self.TSCPeoplePickerPersonSelectedCompletion(nil, (__bridge NSError *)(error));
-                    return;
-                }
-                
-                [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-                    
-                    if (granted) {
-                        
-                        ABPeoplePickerNavigationController *viewController = [self sharedPeoplePicker];
-                        viewController.peoplePickerDelegate = self;
-                        
-                        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-                            
-                            presentingViewController.modalPresentationStyle = UIModalPresentationFormSheet;
-                            viewController.modalPresentationStyle = UIModalPresentationFormSheet;
-                        }
-                        [presentingViewController presentViewController:viewController animated:true completion:nil];
-                    } else {
-                        
-                        self.TSCPeoplePickerPersonSelectedCompletion(nil, [NSError errorWithDomain:TSCAddressBookErrorDomain code:401 userInfo:nil]);
-                    }
-                }];
-            });
-        });
+        presentingViewController.modalPresentationStyle = UIModalPresentationFormSheet;
+        contactViewController.modalPresentationStyle = UIModalPresentationFormSheet;
     }
-}
-
-- (ABPeoplePickerNavigationController *)sharedPeoplePicker {
-    
-    static ABPeoplePickerNavigationController *_sharedPicker = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        
-        _sharedPicker = [[ABPeoplePickerNavigationController alloc] init];
-    });
-    
-    return _sharedPicker;
+    [presentingViewController presentViewController:contactViewController animated:true completion:nil];
 }
 
 #pragma mark - Converting and extracting users
 
-- (TSCPerson *)personWithRecordIdentifier:(id)identifier
+- (TSCPerson *)personWithRecordIdentifier:(NSString *)identifier
 {
-    if ([identifier isKindOfClass:[NSNumber class]]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        return [self personWithRecordNumber:(NSNumber *)identifier];
-#pragma clang diagnostic pop
+    
+    CNContact *newContact = [self contactForIdentifier:identifier];
+    
+    if (newContact) {
+        return [[TSCPerson alloc] initWithContact:newContact];
     } else {
-        return [self personWithRecordString:(NSString *)identifier];
+        return nil;
     }
     
     return nil;
-}
-
-- (TSCPerson *)personWithRecordString:(NSString *)recordIdentifier
-{
-    if (NSStringFromClass([CNContact class])) {
-        
-        CNContact *newContact = [self contactForIdentifier:recordIdentifier];
-        
-        if (newContact) {
-            return [[TSCPerson alloc] initWithContact:newContact];
-        } else {
-            return nil;
-        }
-    }
-    
-    return nil;
-}
-
-- (TSCPerson *)personWithRecordNumber:(NSNumber *)number
-{
-    if (NSStringFromClass([CNContact class])) {
-        
-        CNContact *newContact = [self contactForIdentifier:number];
-        
-        if (newContact) {
-            return [[TSCPerson alloc] initWithContact:newContact];
-        } else {
-            return nil;
-        }
-        
-    } else {
-        
-        ABRecordID recordIdentifier = [self recordIDForNumber:number];
-        return [self personWithRecordID:recordIdentifier];
-    }
-}
-
-- (TSCPerson *)personWithRecordID:(ABRecordID)identifier
-{
-    __block ABRecordRef personRecord;
-    
-    dispatch_sync(self.addressBookQueue, ^{
-        personRecord = ABAddressBookGetPersonWithRecordID(self.addressBook, identifier);
-    });
-    
-    if(personRecord != NULL) {
-        return [self personWithRecordRef:personRecord];
-    }
-    return nil;
-}
-
-- (TSCPerson *)personWithRecordRef:(ABRecordRef)ref
-{
-    TSCPerson *newPerson = [[TSCPerson alloc] initWithABRecordRef:ref];
-    return newPerson;
-}
-
-- (ABRecordID)recordIDForNumber:(NSNumber *)number
-{
-    ABRecordID recordIdentifier = (ABRecordID)[number intValue];
-    return recordIdentifier;
 }
 
 - (void)extractAllContactsWithCompletion:(TSCAllContactsCompletion)completion
 {
-    if (NSStringFromClass([CNContact class])) {
+    
+    CNContactStore *store = [CNContactStore new];
+    CNContactFetchRequest *fetchRequest = [[CNContactFetchRequest alloc] initWithKeysToFetch:[self contactKeysToFetch]];
+    NSError *error = nil;
+    
+    NSMutableArray *contacts = [NSMutableArray new];
+    [store enumerateContactsWithFetchRequest:fetchRequest error:&error usingBlock:^(CNContact * _Nonnull contact, BOOL * _Nonnull stop) {
+        [contacts addObject:[[TSCPerson alloc] initWithContact:contact]];
+    }];
+    
+    if (error) {
         
-        CNContactStore *store = [CNContactStore new];
-        CNContactFetchRequest *fetchRequest = [[CNContactFetchRequest alloc] initWithKeysToFetch:[self contactKeysToFetch]];
-        NSError *error = nil;
-        
-        NSMutableArray *contacts = [NSMutableArray new];
-        [store enumerateContactsWithFetchRequest:fetchRequest error:&error usingBlock:^(CNContact * _Nonnull contact, BOOL * _Nonnull stop) {
-            [contacts addObject:[[TSCPerson alloc] initWithContact:contact]];
-        }];
-        
-        if (error) {
-            
-            if (completion) {
-                completion(nil, error);
-            }
-        } else {
-            
-            if (completion) {
-                completion(contacts, nil);
-            }
+        if (completion) {
+            completion(nil, error);
         }
-        
     } else {
         
-        dispatch_sync(self.addressBookQueue, ^{
-            
-            ABAddressBookRequestAccessWithCompletion(self.addressBook, ^(bool granted, CFErrorRef error) {
-                
-                if (error) {
-                    
-                    if (completion) {
-                        completion(nil, (__bridge NSError *)(error));
-                    }
-                    return;
-                }
-                
-                [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-                    
-                    if (granted) {
-                        
-                        __block NSMutableArray *addressBookArray = [NSMutableArray new];
-                        __block NSMutableArray *people = [NSMutableArray new];
-                        
-                        dispatch_async(self.addressBookQueue, ^{
-                            
-                            NSArray *sources = (__bridge_transfer NSArray *)ABAddressBookCopyArrayOfAllSources(self.addressBook);
-                            
-                            for (id addressBookSouce in sources) {
-                                
-                                NSArray *contacts = (__bridge_transfer NSArray *)ABAddressBookCopyArrayOfAllPeopleInSourceWithSortOrdering([self addressBook], (__bridge ABRecordRef)(addressBookSouce), kABPersonSortByLastName);
-                                [addressBookArray addObjectsFromArray:contacts];
-                                
-                                // Removes call due to Zombie object crash when call method multiple times, There should be no reason to release this as we don't retain it ourselves so shouldn't be a memory leak. Will leave here incase it causes other issues. Simon :)
-                                //                            CFRelease((__bridge CFTypeRef)(addressBookSouce));
-                            }
-                            
-                            for (id person in addressBookArray) {
-                                [people addObject:[self personWithRecordRef:(__bridge ABRecordRef)person]];
-                            }
-                            
-                            [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-                                
-                                if (completion) {
-                                    completion([NSArray arrayWithArray:people], nil);
-                                }
-                            }];
-                        });
-                        
-                    } else {
-                        
-                        if (completion) {
-                            completion(nil, [NSError errorWithDomain:TSCAddressBookErrorDomain code:401 userInfo:nil]);
-                        }
-                    }
-                }];
-            });
-        });
+        if (completion) {
+            completion(contacts, nil);
+        }
     }
 }
 
-void TSCAddressBookInternalChangeCallback (ABAddressBookRef addressBook, CFDictionaryRef info, void *context)
+- (CNContact *)contactForIdentifier:(NSString *)identifier
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:TSCAddressBookChangeNotification object:nil];
+    CNContactStore *store = [CNContactStore new];
+    return [store unifiedContactWithIdentifier:identifier keysToFetch:[self contactKeysToFetch] error:nil];
 }
 
-void TSCAddressBookExternalChangeCallback (ABAddressBookRef addressBook, CFDictionaryRef info, void *context)
-{
-    dispatch_sync([[TSCContactsController sharedController] addressBookQueue], ^{
-        
-        [TSCContactsController sharedController].addressBook = nil;
-    });
-    [[NSNotificationCenter defaultCenter] postNotificationName:TSCAddressBookChangeNotification object:nil];
-}
-
-- (ABRecordRef)recordRefForRecordID:(ABRecordID)recordID
-{
-    __block ABRecordRef personRecord;
-    
-    dispatch_sync(self.addressBookQueue, ^{
-        personRecord = ABAddressBookGetPersonWithRecordID(self.addressBook, recordID);
-    });
-    
-    if(personRecord != NULL) {
-        return personRecord;
-    }
-    return nil;
-}
-
-- (CNContact *)contactForIdentifier:(id)identifier
+- (CNContact *)contactForLegacyIdentifier:(id)identifier
 {
     if ([identifier isKindOfClass:[NSString class]]) {
         
@@ -357,53 +141,13 @@ void TSCAddressBookExternalChangeCallback (ABAddressBookRef addressBook, CFDicti
 
 #pragma mark - Presenting/Editing contacts
 
-- (ABPersonViewController *)personViewControllerForRecordNumber:(NSNumber *)number
+- (CNContactViewController *)personViewControllerForRecordIdentifier:(NSString *)identifier
 {
-    return [self personViewControllerForRecordID:[self recordIDForNumber:number]];
+    CNContactViewController *contactViewController = [CNContactViewController viewControllerForContact:[self contactForIdentifier:identifier]];
+    return contactViewController;
 }
 
-- (ABPersonViewController *)personViewControllerForRecordID:(ABRecordID)recordID
-{
-    ABPersonViewController *view = [[ABPersonViewController alloc] init];
-    view.displayedPerson = [self recordRefForRecordID:recordID];
-    view.personViewDelegate = self;
-    
-    return view;
-}
-
-- (UIViewController *)personViewControllerForRecordIdentifier:(id)identifier
-{
-    if (NSStringFromClass([CNContactViewController class])) {
-        
-        CNContactViewController *contactViewController = [CNContactViewController viewControllerForContact:[self contactForIdentifier:identifier]]; 
-        return contactViewController;
-    }
-    
-    if ([identifier isKindOfClass:[NSNumber class]]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        return [self personViewControllerForRecordNumber:identifier];
-#pragma clang diagnostic pop
-    }
-    
-    return nil;
-}
-
-- (void)presentPersonWithRecordNumber:(NSNumber *)number inViewController:(UIViewController *)viewController
-{
-    [self presentPersonwithRecordID:[self recordIDForNumber:number] inViewController:viewController];
-}
-
-- (void)presentPersonwithRecordID:(ABRecordID)recordID inViewController:(UIViewController *)viewController
-{
-    ABPersonViewController *view = [self personViewControllerForRecordID:recordID];
-    view.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(handleDismissPeopleView:)];
-    
-    self.presentedPersonViewController = [[UINavigationController alloc] initWithRootViewController:view];
-    [viewController presentViewController:self.presentedPersonViewController animated:true completion:nil];
-}
-
-- (void)presentPersonWithRecordIdentifier:(id)identifier inViewController:(UIViewController *)viewController
+- (void)presentPersonWithRecordIdentifier:(NSString *)identifier inViewController:(UIViewController *)viewController
 {
     UIViewController *view = [self personViewControllerForRecordIdentifier:identifier];
     view.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(handleDismissPeopleView:)];
@@ -414,13 +158,7 @@ void TSCAddressBookExternalChangeCallback (ABAddressBookRef addressBook, CFDicti
 
 - (void)handleDismissPeopleView:(UIBarButtonItem *)button
 {
-    if (self.presentedPersonViewController.viewControllers.count > 0 && [self.presentedPersonViewController.viewControllers[0] isKindOfClass:[ABPersonViewController class]]) {
-        
-        ABPersonViewController *viewController = (ABPersonViewController *)self.presentedPersonViewController.viewControllers[0];
-        TSCPerson *editedPerson = [self personWithRecordRef:viewController.displayedPerson];
-        [editedPerson updateWithABRecordRef:viewController.displayedPerson];
-        
-    } else if (self.presentedPersonViewController.viewControllers.count > 0 && [self.presentedPersonViewController.viewControllers[0] isKindOfClass:[CNContactViewController class]]) {
+    if (self.presentedPersonViewController.viewControllers.count > 0 && [self.presentedPersonViewController.viewControllers[0] isKindOfClass:[CNContactViewController class]]) {
         
         CNContactViewController *viewController = (CNContactViewController *)self.presentedPersonViewController.viewControllers[0];
         TSCPerson *editedPerson = [self personWithRecordIdentifier:viewController.contact.identifier];
@@ -462,39 +200,6 @@ void TSCAddressBookExternalChangeCallback (ABAddressBookRef addressBook, CFDicti
     return [NSArray arrayWithArray:addressbookIdsArray];
 }
 
-#pragma mark - People picker delegate
-
-- (void)peoplePickerNavigationControllerDidCancel:(ABPeoplePickerNavigationController *)peoplePicker
-{
-    //Handle dismissing
-    self.TSCPeoplePickerPersonSelectedCompletion(nil, nil);
-    [peoplePicker dismissViewControllerAnimated:YES completion:nil];
-}
-
-- (BOOL)peoplePickerNavigationController:(ABPeoplePickerNavigationController *)peoplePicker shouldContinueAfterSelectingPerson:(ABRecordRef)person {
-    
-    TSCPerson *selectedPerson = [self personWithRecordRef:person];
-    self.TSCPeoplePickerPersonSelectedCompletion(selectedPerson, nil);
-    
-    [peoplePicker dismissViewControllerAnimated:YES completion:nil];
-    return NO;
-    
-}
-
-- (BOOL)peoplePickerNavigationController:(ABPeoplePickerNavigationController *)peoplePicker shouldContinueAfterSelectingPerson:(ABRecordRef)person property:(ABPropertyID)property identifier:(ABMultiValueIdentifier)identifier
-{
-    TSCPerson *selectedPerson = [self personWithRecordRef:person];
-    self.TSCPeoplePickerPersonSelectedCompletion(selectedPerson, nil);
-    
-    [peoplePicker dismissViewControllerAnimated:YES completion:nil];
-    return NO;
-}
-
-- (void)peoplePickerNavigationController:(ABPeoplePickerNavigationController *)peoplePicker didSelectPerson:(ABRecordRef)person
-{
-    TSCPerson *selectedPerson = [self personWithRecordRef:person];
-    self.TSCPeoplePickerPersonSelectedCompletion(selectedPerson, nil);
-}
 
 #pragma mark - Contact View Controller Delegate
 
@@ -519,13 +224,6 @@ void TSCAddressBookExternalChangeCallback (ABAddressBookRef addressBook, CFDicti
 {
     TSCPerson *selectedPerson = [[TSCPerson alloc] initWithContact:contact];
     self.TSCPeoplePickerPersonSelectedCompletion(selectedPerson, nil);
-}
-
-#pragma mark - Person View Controller Delegate
-
-- (BOOL)personViewController:(ABPersonViewController *)personViewController shouldPerformDefaultActionForPerson:(ABRecordRef)person property:(ABPropertyID)property identifier:(ABMultiValueIdentifier)valueIdentifier
-{
-    return YES;
 }
 
 #pragma mark - Helpers

--- a/ThunderBasics/TSCPerson.h
+++ b/ThunderBasics/TSCPerson.h
@@ -16,18 +16,6 @@
  */
 @interface TSCPerson : NSObject
 
-/**
- Takes a ABRecordRef from the addressbook and converts it into a TSCPerson
- @param ref A `ABRecordRef` extracted from an `ABAddressBook`
- @return A populated TSCObject
- */
-- (instancetype _Nonnull)initWithABRecordRef:(ABRecordRef _Nonnull)ref;
-
-/**
- Updates the current model using an `ABRecordRef`
- @param ref The record Ref to update the current person model with
- */
-- (void)updateWithABRecordRef:(ABRecordRef _Nonnull)ref;
 
 /**
  Takes a CNContact from Contacts framework and converts it into a TSCPerson
@@ -101,17 +89,12 @@
  */
 @property (nonatomic, strong) UIImage * _Nullable largeImage;
 
-/**
- The record ID number of the record in relation to the addressbook it was extracted from
- @note This record ID could change and Apple recommends implementing checks to make sure you get the expected person back when using this ID.
- */
-@property (nonatomic, strong) NSNumber * _Nullable recordNumber __attribute((deprecated("Please use recordIdentifier instead")));
 
 /**
  The record ID of the record in relation to where it was extracted from
  @note Before iOS 9 this record ID could change and Apple recommends implementing checks to make sure you get the expected person back when using this ID.
  */
-@property (nonatomic, strong) id _Nullable recordIdentifier;
+@property (nonatomic, strong) NSString * _Nullable recordIdentifier;
 
 /**
  The persons mobile number, if available.

--- a/ThunderBasics/TSCPerson.m
+++ b/ThunderBasics/TSCPerson.m
@@ -22,25 +22,6 @@ typedef NS_ENUM(NSUInteger, TSCPersonSource) {
 
 @implementation TSCPerson
 
-- (instancetype)initWithABRecordRef:(ABRecordRef)ref
-{
-    if (self = [super init]) {
-        
-        self.source = TSCPersonSourceABAddressBook;
-        [self updateWithABRecordRef:ref];
-        
-        self.observer = [[NSNotificationCenter defaultCenter] addObserverForName:TSCAddressBookChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-                
-            TSCContactsController *contactsController = [TSCContactsController sharedController];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            [self updateWithABRecordRef:[contactsController recordRefForRecordID:[contactsController recordIDForNumber:self.recordNumber]]];
-#pragma clang diagnostic pop
-        }];
-    }
-    return self;
-}
-
 - (instancetype)initWithContact:(CNContact *)contact
 {
     if (self = [super init]) {
@@ -48,14 +29,11 @@ typedef NS_ENUM(NSUInteger, TSCPersonSource) {
         self.source = TSCPersonSourceContactsFramework;
         [self updateWithCNContact:contact];
         
-        if (NSStringFromClass([CNContactStore class])) {
+        self.observer = [[NSNotificationCenter defaultCenter] addObserverForName:TSCAddressBookChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
             
-            self.observer = [[NSNotificationCenter defaultCenter] addObserverForName:TSCAddressBookChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
-                
-                TSCContactsController *contactsController = [TSCContactsController sharedController];
-                [self updateWithCNContact:[contactsController contactForIdentifier:self.recordIdentifier]];
-            }];
-        }
+            TSCContactsController *contactsController = [TSCContactsController sharedController];
+            [self updateWithCNContact:[contactsController contactForIdentifier:self.recordIdentifier]];
+        }];
     }
     return self;
 }
@@ -110,121 +88,6 @@ typedef NS_ENUM(NSUInteger, TSCPersonSource) {
     
     if (!self.photo) {
         
-        self.hasPlaceholderImage = YES;
-        self.photo = [self contactPlaceholderWithInitials:self.initials];
-    }
-}
-
-- (void)updateWithABRecordRef:(ABRecordRef)ref
-{
-    self.mobileNumber = nil;
-    self.firstName = nil;
-    self.lastName = nil;
-    self.numbers = nil;
-    self.email = nil;
-    self.photo = nil;
-    self.largeImage = nil;
-    self.recordIdentifier = nil;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    self.recordNumber = nil;
-#pragma clang diagnostic pop    
-    self.hasPlaceholderImage = false;
-    
-    CFTypeRef firstNameRef = ABRecordCopyValue(ref, kABPersonFirstNameProperty);
-    self.firstName = (__bridge NSString *)firstNameRef;
-    if (firstNameRef) {
-        CFRelease(firstNameRef);
-    }
-    
-    CFTypeRef lastNameRef = ABRecordCopyValue(ref, kABPersonLastNameProperty);
-    self.lastName = (__bridge NSString *)lastNameRef;
-    if (lastNameRef) {
-        CFRelease(lastNameRef);
-    }
-    
-    CFTypeRef companyNameFor = ABRecordCopyValue(ref, kABPersonOrganizationProperty);
-    self.companyName = (__bridge NSString *)companyNameFor;
-    if (companyNameFor) {
-        CFRelease(companyNameFor);
-    }
-    
-    if (!self.firstName && !self.lastName) {
-        self.firstName = self.companyName;
-    }
-    
-    ABMultiValueRef phoneRef = ABRecordCopyValue(ref, kABPersonPhoneProperty);
-    CFArrayRef numbersRef = ABMultiValueCopyArrayOfAllValues(phoneRef);
-    NSArray *numbers = (__bridge NSArray *)numbersRef;
-    self.numbers = numbers;
-    
-    if (phoneRef) {
-        CFRelease(phoneRef);
-    }
-    if (numbersRef) {
-        CFRelease(numbersRef);
-    }
-    
-    ABMultiValueRef phoneNumbers = ABRecordCopyValue(ref, kABPersonPhoneProperty);
-    
-    for (CFIndex i = 0; i < ABMultiValueGetCount(phoneNumbers); i++) {
-        
-        CFStringRef numberRef = ABMultiValueCopyValueAtIndex(phoneNumbers, i);
-        CFStringRef locLabel = ABMultiValueCopyLabelAtIndex(phoneNumbers, i);
-        NSString *phoneNumber = (__bridge NSString *)numberRef;
-
-        
-        if (locLabel != NULL) {
-            
-            if (CFStringCompare(locLabel, kABPersonPhoneMobileLabel, 0) == kCFCompareEqualTo || CFStringCompare(locLabel, kABPersonPhoneIPhoneLabel, 0) == kCFCompareEqualTo) {
-                self.mobileNumber = phoneNumber;
-            }
-        }
-        
-        if (numberRef) {
-            CFRelease(numberRef);
-        }
-        if (locLabel) {
-            CFRelease(locLabel);
-        }
-    }
-    if (phoneNumbers) {
-        CFRelease(phoneNumbers);
-    }
-    
-    ABMultiValueRef emailsPropertyRef = ABRecordCopyValue(ref, kABPersonEmailProperty);
-    CFArrayRef emailsRef = ABMultiValueCopyArrayOfAllValues(emailsPropertyRef);
-    NSArray *emails = (__bridge NSArray *)emailsRef;
-    self.email = [emails firstObject];
-    if (emailsPropertyRef) {
-        CFRelease(emailsPropertyRef);
-    }
-    if (emailsRef) {
-        CFRelease(emailsRef);
-    }
-    
-    CFDataRef photoRef = ABPersonCopyImageDataWithFormat(ref, kABPersonImageFormatThumbnail);
-    NSData *photoData = (__bridge NSData *)photoRef;
-    self.photo = [UIImage imageWithData:photoData];
-    if (photoRef) {
-        CFRelease(photoRef);
-    }
-    
-    
-    CFDataRef originalPhotoRef = ABPersonCopyImageDataWithFormat(ref, kABPersonImageFormatOriginalSize);
-    NSData *originalPhotoData = (__bridge NSData *)originalPhotoRef;
-    self.largeImage = [UIImage imageWithData:originalPhotoData];
-    if (originalPhotoRef) {
-        CFRelease(originalPhotoRef);
-    }
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    self.recordNumber = [NSNumber numberWithInt:(int)ABRecordGetRecordID(ref)];
-#pragma clang diagnostic pop
-    self.recordIdentifier = [NSNumber numberWithInt:(int)ABRecordGetRecordID(ref)];
-    
-    if (!self.photo) {
         self.hasPlaceholderImage = YES;
         self.photo = [self contactPlaceholderWithInitials:self.initials];
     }


### PR DESCRIPTION
WOHOOOOO!

Only thing i've left is a method called `- (CNContact *)contactForLegacyIdentifier:(id)identifier;` in case we still have apps that have saved records from ABAddressBook
