### PR TITLE
Changes TSCObjects serialisableRepresentation header to return NSDict…

### DIFF
--- a/ThunderBasics/TSCObject.h
+++ b/ThunderBasics/TSCObject.h
@@ -15,7 +15,7 @@
  Serialises the object to an object which can be sent using a web request.
  @discussion As a base class `TSCObject` returns an `NSDictionary` containing all the properties on your subclass. Override this to implement custom serialisation.
  */
-- (id)serialisableRepresentation;
+- (NSDictionary *)serialisableRepresentation;
 
 /**
  Returns a pretty printed JSON representation of the `TSCObject`.


### PR DESCRIPTION
…ionary instead of ‘id’ as it should never return anything other than a NSDictionary, this allows for much better swift compatibility as we no longer have to cast objects from Any