### PR TITLE
Fixes multiple MDCHUDActivityView's being dismissed

### DIFF
--- a/ThunderBasics/MDCHUDActivityView.m
+++ b/ThunderBasics/MDCHUDActivityView.m
@@ -15,6 +15,8 @@
 @property (nonatomic, strong) UILabel *textLabel;
 @property (nonatomic, strong) UIImageView *logoView;
 
+@property (nonatomic, assign, getter=isDismissing) BOOL dismissing;
+
 @end
 
 @implementation MDCHUDActivityView
@@ -122,9 +124,14 @@
 
 + (MDCHUDActivityView *)activityInView:(UIView *)view
 {
-    for (MDCHUDActivityView *activityView in view.subviews) {
-        if ([activityView isKindOfClass:[MDCHUDActivityView class]]) {
-            return activityView;
+    for (MDCHUDActivityView *subview in view.subviews) {
+        
+        if ([subview isKindOfClass:[MDCHUDActivityView class]]) {
+            
+            MDCHUDActivityView *activityView = (MDCHUDActivityView *)subview;
+            if (!activityView.isDismissing) {
+                return activityView;
+            }
         }
     }
     
@@ -178,6 +185,8 @@
 
 - (void)finish
 {
+    self.dismissing = true;
+    
     [UIView animateWithDuration:0.35 animations:^{
         
         self.transform = CGAffineTransformMakeScale(0.01, 0.01);


### PR DESCRIPTION
Fixes multiple MDCHUDActivityView's being dismissed within 0.35 seconds of each other. This was noticed in the prep apps preparing for Hurricane Florence where the shelters and hurricane overlay requests were completing at a similar time (Due to lots of shelters and hurricanes being present).