### PR TITLE
Changing MCDHUDActivityView to use identifiers for dismissal.

### DIFF
--- a/ThunderBasics/MDCHUDActivityView.h
+++ b/ThunderBasics/MDCHUDActivityView.h
@@ -63,11 +63,11 @@ typedef NS_ENUM(NSInteger, MDCHUDActivityViewStyle) {
 /**
  *  Updates the text label beneath an already running loading indicator
  *
- *  @param view The view which already contains a loading HUD
- *  @param text The text to replace the existing text with in the view
+ *  @param view The view which already contains a loading HUD.
  *  @param identifier The identifier of the activity view we want to update.
+ *  @param text The text to replace the existing text with in the view.
  */
-+ (void)updateActivityInView:(UIView *)view withText:(NSString *)text andIdentifier:(NSString*)identifier;
++ (void)updateActivityInView:(UIView *)view withIdentifier:(NSString*)identifier toText:(NSString *)text;
 
 /**
  *  Removes text from the given activity view

--- a/ThunderBasics/MDCHUDActivityView.h
+++ b/ThunderBasics/MDCHUDActivityView.h
@@ -29,16 +29,18 @@ typedef NS_ENUM(NSInteger, MDCHUDActivityViewStyle) {
  *  Adds an animated HUD to the centre of the view to indicate loading
  *
  *  @param view The view that should present the loading HUD
+ *  @param identifier The identifier that'll be used to reference the activity view at a future point.
  */
-+ (void)startInView:(UIView *)view;
++ (void)startInView:(UIView *)view identifier:(NSString*)identifier;
 
 /**
  *  Adds an animated HUD to the centre of the view to indicate loading with a message displayed underneath the activity indicator
  *
  *  @param view The view that should present the loading HUD
  *  @param text The text to display beneath the indicator
+ *  @param identifier The identifier that'll be used to reference the activity view at a future point.
  */
-+ (void)startInView:(UIView *)view text:(NSString *)text;
++ (void)startInView:(UIView *)view text:(NSString *)text identifier:(NSString*)identifier;
 
 /**
  *  Adds an animated HUD to the centre of the view to indicate loading with a message displayed underneath the activity indicator. Choose from a range of styles.
@@ -46,29 +48,33 @@ typedef NS_ENUM(NSInteger, MDCHUDActivityViewStyle) {
  *  @param view  The view that should present the loading HUD
  *  @param text  The text to display beneath the indicator
  *  @param style The MDCHUDActivityViewStyle that should be used to layout the view
+ *  @param identifier The identifier that'll be used to reference the activity view at a future point.
  */
-+ (void)startInView:(UIView *)view text:(NSString *)text style:(MDCHUDActivityViewStyle)style;
++ (void)startInView:(UIView *)view text:(NSString *)text style:(MDCHUDActivityViewStyle)style identifier:(NSString*)identifier;
 
 /**
  *  Removes any loading HUD views from the specified view
  *
  *  @param view The view which already contains a loading HUD
+ *  @param identifier The identifier of the activity view we want to finish.
  */
-+ (void)finishInView:(UIView *)view;
++ (void)finishInView:(UIView *)view withIdentifier:(NSString*)identifier;
 
 /**
  *  Updates the text label beneath an already running loading indicator
  *
  *  @param view The view which already contains a loading HUD
  *  @param text The text to replace the existing text with in the view
+ *  @param identifier The identifier of the activity view we want to update.
  */
-+ (void)updateActivityInView:(UIView *)view withText:(NSString *)text;
++ (void)updateActivityInView:(UIView *)view withText:(NSString *)text andIdentifier:(NSString*)identifier;
 
 /**
  *  Removes text from the given activity view
  *
  *  @param view The view which already contains a loading HUD
+*  @param identifier The identifier of the activity view we want to remove the text from.
  */
-+ (void)removeTextOnActivityViewInView:(UIView *)view;
++ (void)removeTextOnActivityViewInView:(UIView *)view identifier:(NSString*)identifier;
 
 @end

--- a/ThunderBasics/MDCHUDActivityView.h
+++ b/ThunderBasics/MDCHUDActivityView.h
@@ -75,6 +75,6 @@ typedef NS_ENUM(NSInteger, MDCHUDActivityViewStyle) {
  *  @param view The view which already contains a loading HUD
 *  @param identifier The identifier of the activity view we want to remove the text from.
  */
-+ (void)removeTextOnActivityViewInView:(UIView *)view identifier:(NSString*)identifier;
++ (void)removeTextOnActivityViewInView:(UIView *)view withIdentifier:(NSString*)identifier;
 
 @end

--- a/ThunderBasics/MDCHUDActivityView.m
+++ b/ThunderBasics/MDCHUDActivityView.m
@@ -15,14 +15,17 @@
 @property (nonatomic, strong) UILabel *textLabel;
 @property (nonatomic, strong) UIImageView *logoView;
 
-@property (nonatomic, assign, getter=isDismissing) BOOL dismissing;
+/**
+ Defines the activity view's identifier, so it can be removed while leaving any others intact.
+ */
+@property (nonatomic, strong) NSString *identifier;
 
 @end
 
 @implementation MDCHUDActivityView
 
 #pragma mark - Setup
-- (instancetype)initWithStyle:(MDCHUDActivityViewStyle)style
+- (instancetype)initWithStyle:(MDCHUDActivityViewStyle)style identifier:(NSString*)identifier
 {
     if (self = [super initWithFrame:CGRectMake(0, 0, 100, 100)]) {
         
@@ -41,6 +44,8 @@
             [self addSubview:self.activityIndicatorView];
             [self.activityIndicatorView startAnimating];
         }
+        
+        self.identifier = identifier;
         
         self.textLabel = [UILabel new];
         self.textLabel.textAlignment = NSTextAlignmentCenter;
@@ -68,19 +73,19 @@
 
 #pragma mark - Adding
 
-+ (void)startInView:(UIView *)view
++ (void)startInView:(UIView *)view identifier:(NSString*)identifier
 {
-    [MDCHUDActivityView startInView:view text:nil];
+    [MDCHUDActivityView startInView:view text:nil identifier:identifier];
 }
 
-+ (void)startInView:(UIView *)view text:(NSString *)text
++ (void)startInView:(UIView *)view text:(NSString *)text identifier:(NSString*)identifier
 {
-    [MDCHUDActivityView startInView:view text:text style:MDCHUDActivityViewStyleDefault];
+    [MDCHUDActivityView startInView:view text:text style:MDCHUDActivityViewStyleDefault identifier:identifier];
 }
 
-+ (void)startInView:(UIView *)view text:(NSString *)text style:(MDCHUDActivityViewStyle)style
++ (void)startInView:(UIView *)view text:(NSString *)text style:(MDCHUDActivityViewStyle)style identifier:(NSString*)identifier
 {
-    MDCHUDActivityView *activityView = [[MDCHUDActivityView alloc] initWithStyle:style];
+    MDCHUDActivityView *activityView = [[MDCHUDActivityView alloc] initWithStyle:style identifier:identifier];
     activityView.textLabel.text = text;
     
     [activityView showInView:view];
@@ -122,14 +127,14 @@
 
 #pragma mark - Modifying existing
 
-+ (MDCHUDActivityView *)activityInView:(UIView *)view
++ (MDCHUDActivityView *)activityInView:(UIView *)view withIdentifier:(NSString*)identifier
 {
     for (MDCHUDActivityView *subview in view.subviews) {
         
         if ([subview isKindOfClass:[MDCHUDActivityView class]]) {
             
             MDCHUDActivityView *activityView = (MDCHUDActivityView *)subview;
-            if (!activityView.isDismissing) {
+            if ([activityView.identifier isEqualToString:identifier]) {
                 return activityView;
             }
         }
@@ -138,9 +143,9 @@
     return nil;
 }
 
-+ (void)updateActivityInView:(UIView *)view withText:(NSString *)text
++ (void)updateActivityInView:(UIView *)view withText:(NSString *)text andIdentifier:(NSString*)identifier
 {
-    MDCHUDActivityView *activityView = [MDCHUDActivityView activityInView:view];
+    MDCHUDActivityView *activityView = [MDCHUDActivityView activityInView:view withIdentifier:identifier];
     
     if (!activityView.textLabel.text) {
         
@@ -169,24 +174,22 @@
     }
 }
 
-+ (void)removeTextOnActivityViewInView:(UIView *)view
++ (void)removeTextOnActivityViewInView:(UIView *)view identifier:(NSString*)identifier
 {
-    [MDCHUDActivityView updateActivityInView:view withText:nil];
+    [MDCHUDActivityView updateActivityInView:view withText:nil andIdentifier:identifier];
 }
 
 #pragma mark - Removing
 
-+ (void)finishInView:(UIView *)view
++ (void)finishInView:(UIView *)view withIdentifier:(NSString*)identifier
 {
-    MDCHUDActivityView *activityView = [MDCHUDActivityView activityInView:view];
+    MDCHUDActivityView *activityView = [MDCHUDActivityView activityInView:view withIdentifier:identifier];
     
     [activityView finish];
 }
 
 - (void)finish
 {
-    self.dismissing = true;
-    
     [UIView animateWithDuration:0.35 animations:^{
         
         self.transform = CGAffineTransformMakeScale(0.01, 0.01);

--- a/ThunderBasics/MDCHUDActivityView.m
+++ b/ThunderBasics/MDCHUDActivityView.m
@@ -174,7 +174,7 @@
     }
 }
 
-+ (void)removeTextOnActivityViewInView:(UIView *)view identifier:(NSString*)identifier
++ (void)removeTextOnActivityViewInView:(UIView *)view withIdentifier:(NSString*)identifier
 {
     [MDCHUDActivityView updateActivityInView:view withIdentifier:identifier toText:nil];
 }

--- a/ThunderBasics/MDCHUDActivityView.m
+++ b/ThunderBasics/MDCHUDActivityView.m
@@ -143,7 +143,7 @@
     return nil;
 }
 
-+ (void)updateActivityInView:(UIView *)view withText:(NSString *)text andIdentifier:(NSString*)identifier
++ (void)updateActivityInView:(UIView *)view withIdentifier:(NSString*)identifier toText:(NSString *)text
 {
     MDCHUDActivityView *activityView = [MDCHUDActivityView activityInView:view withIdentifier:identifier];
     
@@ -176,7 +176,7 @@
 
 + (void)removeTextOnActivityViewInView:(UIView *)view identifier:(NSString*)identifier
 {
-    [MDCHUDActivityView updateActivityInView:view withText:nil andIdentifier:identifier];
+    [MDCHUDActivityView updateActivityInView:view withIdentifier:identifier toText:nil];
 }
 
 #pragma mark - Removing


### PR DESCRIPTION
In order to always remove the correct activity view, identifiers will be required upon creation so that they can be referenced at the point they should be removed. This replaces the previous functionality where the first non-dismissing activity view was always dismissed - which may not match the one we're wanting to dismiss.

A side effect of this, that we should bare in mind, is that projects will need to be updated to use the new identifier parameter, but beyond that everything else is handled internally.