### PR TITLE
Changed ToastView access modifiers to allow for usage

### DIFF
--- a/ThunderBasics/ToastView.swift
+++ b/ThunderBasics/ToastView.swift
@@ -43,7 +43,7 @@ public class ToastView: UIView {
     ///   - message: The message text to display on the toast
     ///   - image: The image to display on the left hand side of the toast
     ///   - action: The action to be called if the user taps the toast
-    init(title: String?, message: String?, image: UIImage?, action: ToastActionHandler?) {
+    public init(title: String?, message: String?, image: UIImage?, action: ToastActionHandler?) {
         
         super.init(frame: .zero)
         
@@ -89,7 +89,7 @@ public class ToastView: UIView {
     /// Shows the toast notification on the screen
     ///
     /// - Parameter completion: A completion block to be called when the toast notification has displayed and dismissed successfully
-    func show(completion: @escaping () -> Void) {
+    public func show(completion: @escaping () -> Void) {
         
         frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44) // Add on 40 points so when it drops down you can't see the view behind it.
         layout()

--- a/ThunderBasics/ToastView.swift
+++ b/ThunderBasics/ToastView.swift
@@ -89,7 +89,7 @@ public class ToastView: UIView {
     /// Shows the toast notification on the screen
     ///
     /// - Parameter completion: A completion block to be called when the toast notification has displayed and dismissed successfully
-    public func show(completion: @escaping () -> Void) {
+    internal func show(completion: @escaping () -> Void) {
         
         frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44) // Add on 40 points so when it drops down you can't see the view behind it.
         layout()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes some access modifiers within ToastView, to allow for them to be created outside of the ThunderBasics framework

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will allow for ToastViews to be created outside of the ThunderBasics project, which is required functionality for one of the mobile apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by:
- Making the change in the app's carthage submodule
- Rebuilding the dependencies to use the altered change
- Running the app

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
