### PR TITLE
Adds accessibility `UIViewController` subclass

### DIFF
--- a/ThunderBasics.xcodeproj/project.pbxproj
+++ b/ThunderBasics.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		B16234D21C91F775001669BA /* ThunderBasicsMac.h in Headers */ = {isa = PBXBuildFile; fileRef = B16234D11C91F775001669BA /* ThunderBasicsMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B16234EC1C91FA3C001669BA /* NSObject+AddedProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = B1B6CF891C4E47DB00CDC978 /* NSObject+AddedProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B163D2FE1FB33F6C00BF4CEC /* DynamicFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = B163D2FD1FB33F6C00BF4CEC /* DynamicFont.swift */; };
+		B1898CD1230D7A9000A1F5D1 /* AccessibilityRefreshingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1898CD0230D7A9000A1F5D1 /* AccessibilityRefreshingViewController.swift */; };
 		B190A858228DBCB600E44821 /* ThunderBasicsTests_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B190A857228DBCB600E44821 /* ThunderBasicsTests_macOS.swift */; };
 		B190A85A228DBCB600E44821 /* ThunderBasics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B16234AB1C91F5E3001669BA /* ThunderBasics.framework */; };
 		B190A860228DBE6000E44821 /* UIColorHexStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B146C3CD2190978900A1DBCD /* UIColorHexStringTests.swift */; };
@@ -119,6 +120,7 @@
 		B16234C41C91F625001669BA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B16234D11C91F775001669BA /* ThunderBasicsMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThunderBasicsMac.h; sourceTree = "<group>"; };
 		B163D2FD1FB33F6C00BF4CEC /* DynamicFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFont.swift; sourceTree = "<group>"; };
+		B1898CD0230D7A9000A1F5D1 /* AccessibilityRefreshingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityRefreshingViewController.swift; sourceTree = "<group>"; };
 		B190A855228DBCB600E44821 /* ThunderBasicsTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ThunderBasicsTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B190A857228DBCB600E44821 /* ThunderBasicsTests_macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThunderBasicsTests_macOS.swift; sourceTree = "<group>"; };
 		B190A859228DBCB600E44821 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -287,6 +289,14 @@
 			name = Fonts;
 			sourceTree = "<group>";
 		};
+		B1898CCF230D7A7600A1F5D1 /* Accessibility */ = {
+			isa = PBXGroup;
+			children = (
+				B1898CD0230D7A9000A1F5D1 /* AccessibilityRefreshingViewController.swift */,
+			);
+			name = Accessibility;
+			sourceTree = "<group>";
+		};
 		B190A856228DBCB600E44821 /* ThunderBasicsTests-macOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -385,6 +395,7 @@
 		C272EF8619C831AB004BD339 /* ThunderBasics */ = {
 			isa = PBXGroup;
 			children = (
+				B1898CCF230D7A7600A1F5D1 /* Accessibility */,
 				B163D2FC1FB33F5100BF4CEC /* Fonts */,
 				C272EFB919C8325D004BD339 /* ThunderBasics.h */,
 				B12BD5DE1C48043600D07A58 /* Views */,
@@ -683,6 +694,7 @@
 				B146C3E42191D36A00A1DBCD /* UIViewController+DismissAnimated.swift in Sources */,
 				B1E6FC49218C729500971DC3 /* UIColor+Comparison.swift in Sources */,
 				B146C3BA21906B8A00A1DBCD /* UIView+Frame.swift in Sources */,
+				B1898CD1230D7A9000A1F5D1 /* AccessibilityRefreshingViewController.swift in Sources */,
 				B152AC501F20BF020079372B /* DateHelpers.swift in Sources */,
 				49CF13291AB6D88A00AA5971 /* TSCContactsController.m in Sources */,
 				B146C3E22191CB2400A1DBCD /* UIWindow+VisibleViewController.swift in Sources */,

--- a/ThunderBasics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ThunderBasics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A UIViewController which subscribes to accessibility setting change notifications such as `darkerSystemColorsStatusDidChangeNotification` and calls an overrideable function whenever they do change.
-open class AccessibilityRefreshingViewController: UIViewController {
+open class AccessibilityRefreshingViewController: UIViewController, UIContentSizeCategoryAdjusting {
     
     /// Observer listening to dynamic font changes
     private var dynamicChangeObserver: NSObjectProtocol?
@@ -17,8 +17,7 @@ open class AccessibilityRefreshingViewController: UIViewController {
     /// Observer listening to accessibility setting changed notifications
     private var accessibilityObservers: [Any] = []
 
-    /// Whether the table view should redraw when the devices content size changes
-    public var shouldRedrawWithContentSizeChange = true
+    public var adjustsFontForContentSizeCategory: Bool = true
     
     /// A list of notification names that should cause the table view to redraw itself
     public var accessibilityRedrawNotificationNames: [Notification.Name] = [
@@ -34,7 +33,7 @@ open class AccessibilityRefreshingViewController: UIViewController {
         super.viewWillAppear(animated)
         
         dynamicChangeObserver = NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: self, queue: .main) { [weak self] (notification) in
-            guard let strongSelf = self, strongSelf.shouldRedrawWithContentSizeChange else { return }
+            guard let strongSelf = self, strongSelf.adjustsFontForContentSizeCategory else { return }
             strongSelf.accessibilitySettingsDidChange()
         }
         

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -17,6 +17,7 @@ open class AccessibilityRefreshingViewController: UIViewController, UIContentSiz
     /// Observer listening to accessibility setting changed notifications
     private var accessibilityObservers: [Any] = []
 
+    /// Indicates whether the table view should call accessibilitySettingsDidChange automatically when the device's UIContentSizeCategory is changed.
     public var adjustsFontForContentSizeCategory: Bool = true
     
     /// A list of notification names that should cause the table view to redraw itself

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -35,7 +35,6 @@ class AccessibilityRefreshingViewController: UIViewController {
         
         dynamicChangeObserver = NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: self, queue: .main) { [weak self] (notification) in
             guard let strongSelf = self, strongSelf.shouldRedrawWithContentSizeChange else { return }
-            strongSelf.reloadVisibleRowsWhilstMaintainingSelection()
             strongSelf.accessibilitySettingsDidChange()
         }
         

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A UIViewController which subscribes to accessibility setting change notifications such as `darkerSystemColorsStatusDidChangeNotification` and calls an overrideable function whenever they do change.
-class AccessibilityRefreshingViewController: UIViewController {
+public class AccessibilityRefreshingViewController: UIViewController {
     
     /// Observer listening to dynamic font changes
     private var dynamicChangeObserver: NSObjectProtocol?

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A UIViewController which subscribes to accessibility setting change notifications such as `darkerSystemColorsStatusDidChangeNotification` and calls an overrideable function whenever they do change.
-public class AccessibilityRefreshingViewController: UIViewController {
+open class AccessibilityRefreshingViewController: UIViewController {
     
     /// Observer listening to dynamic font changes
     private var dynamicChangeObserver: NSObjectProtocol?

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -38,7 +38,10 @@ open class AccessibilityRefreshingViewController: UIViewController, UIContentSiz
             strongSelf.accessibilitySettingsDidChange()
         }
         
-        // Notification names that it makes sense to redraw on
+        // Notification names that it makes sense to redraw on.
+        // Note that these differ from `self.accessibilityRedrawNotificationNames`. It is easier, and not too
+        // expensive to manage which notifications trigger a refresh at the point of receiving the notification
+        // rather than risking double-adding or double-removing the observers!  
         let accessibilityNotifications: [Notification.Name] = [
             UIAccessibility.darkerSystemColorsStatusDidChangeNotification,
             UIAccessibility.assistiveTouchStatusDidChangeNotification,

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -32,7 +32,7 @@ open class AccessibilityRefreshingViewController: UIViewController, UIContentSiz
         
         super.viewWillAppear(animated)
         
-        dynamicChangeObserver = NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: self, queue: .main) { [weak self] (notification) in
+        dynamicChangeObserver = NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: nil, queue: .main) { [weak self] (notification) in
             guard let strongSelf = self, strongSelf.adjustsFontForContentSizeCategory else { return }
             strongSelf.accessibilitySettingsDidChange()
         }
@@ -67,6 +67,7 @@ open class AccessibilityRefreshingViewController: UIViewController, UIContentSiz
         accessibilityObservers = []
         guard let dynamicChangeObserver = dynamicChangeObserver else { return }
         NotificationCenter.default.removeObserver(dynamicChangeObserver)
+        self.dynamicChangeObserver = nil
     }
     
     /// A function called when accessibility settings on-device changed. Has no default implementation.

--- a/ThunderBasics/AccessibilityRefreshingViewController.swift
+++ b/ThunderBasics/AccessibilityRefreshingViewController.swift
@@ -1,0 +1,78 @@
+//
+//  AccessibilityRefreshingViewController.swift
+//  ThunderBasics-iOS
+//
+//  Created by Simon Mitchell on 21/08/2019.
+//  Copyright © 2019 threesidedcube. All rights reserved.
+//
+
+import UIKit
+
+/// A UIViewController which subscribes to accessibility setting change notifications such as `darkerSystemColorsStatusDidChangeNotification` and calls an overrideable function whenever they do change.
+class AccessibilityRefreshingViewController: UIViewController {
+    
+    /// Observer listening to dynamic font changes
+    private var dynamicChangeObserver: NSObjectProtocol?
+    
+    /// Observer listening to accessibility setting changed notifications
+    private var accessibilityObservers: [Any] = []
+
+    /// Whether the table view should redraw when the devices content size changes
+    public var shouldRedrawWithContentSizeChange = true
+    
+    /// A list of notification names that should cause the table view to redraw itself
+    public var accessibilityRedrawNotificationNames: [Notification.Name] = [
+        UIAccessibility.darkerSystemColorsStatusDidChangeNotification,
+        UIAccessibility.boldTextStatusDidChangeNotification,
+        UIAccessibility.grayscaleStatusDidChangeNotification,
+        UIAccessibility.invertColorsStatusDidChangeNotification,
+        UIAccessibility.reduceTransparencyStatusDidChangeNotification
+    ]
+    
+    open override func viewWillAppear(_ animated: Bool) {
+        
+        super.viewWillAppear(animated)
+        
+        dynamicChangeObserver = NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: self, queue: .main) { [weak self] (notification) in
+            guard let strongSelf = self, strongSelf.shouldRedrawWithContentSizeChange else { return }
+            strongSelf.reloadVisibleRowsWhilstMaintainingSelection()
+            strongSelf.accessibilitySettingsDidChange()
+        }
+        
+        // Notification names that it makes sense to redraw on
+        let accessibilityNotifications: [Notification.Name] = [
+            UIAccessibility.darkerSystemColorsStatusDidChangeNotification,
+            UIAccessibility.assistiveTouchStatusDidChangeNotification,
+            UIAccessibility.boldTextStatusDidChangeNotification,
+            UIAccessibility.grayscaleStatusDidChangeNotification,
+            UIAccessibility.guidedAccessStatusDidChangeNotification,
+            UIAccessibility.invertColorsStatusDidChangeNotification,
+            UIAccessibility.reduceMotionStatusDidChangeNotification,
+            UIAccessibility.reduceTransparencyStatusDidChangeNotification
+        ]
+        
+        accessibilityObservers = accessibilityNotifications.map({ (notificationName) -> Any in
+            return NotificationCenter.default.addObserver(forName: notificationName, object: nil, queue: .main, using: { [weak self] (notification) in
+                guard let strongSelf = self, strongSelf.accessibilityRedrawNotificationNames.contains(notification.name) else {
+                    return
+                }
+                strongSelf.accessibilitySettingsDidChange()
+            })
+        })
+    }
+    
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        accessibilityObservers.forEach { (observer) in
+            NotificationCenter.default.removeObserver(observer)
+        }
+        accessibilityObservers = []
+        guard let dynamicChangeObserver = dynamicChangeObserver else { return }
+        NotificationCenter.default.removeObserver(dynamicChangeObserver)
+    }
+    
+    /// A function called when accessibility settings on-device changed. Has no default implementation.
+    open func accessibilitySettingsDidChange() {
+        
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds view controller subclass which calls function when accessibility settings change on-device!
Settings are customisable on the subclass for which notifications trigger the function to be called!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows `ThunderCloud` as well as other projects to refresh their UI automatically based on accessibility changes the user has made.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested by pointing to this branch locally for ARC First Aid

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
