### PR TITLE
Fix/#38 pixel color

### DIFF
--- a/ThunderBasics/UIImage+ColorAnalysis.swift
+++ b/ThunderBasics/UIImage+ColorAnalysis.swift
@@ -225,6 +225,7 @@ extension UIImage {
         let height = Int(size.height)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         
+        // Create graphics context to render image to
         guard let context = CGContext(data: nil,
                                       width: width,
                                       height: height,
@@ -236,6 +237,7 @@ extension UIImage {
                 return nil
         }
         
+        // Re-create the image to make sure the image is RGBA rather than it's original colour space
         context.draw(cgImage, in: CGRect(origin: .zero, size: size))
         
         guard let pixelBuffer = context.data else { return nil }
@@ -243,6 +245,7 @@ extension UIImage {
         let pointer = pixelBuffer.bindMemory(to: UInt32.self, capacity: width * height)
         let pixel = pointer[Int(point.y) * width + Int(point.x)]
         
+        // Get pixel RGBA values
         let r: CGFloat = CGFloat(red(for: pixel))   / 255
         let g: CGFloat = CGFloat(green(for: pixel)) / 255
         let b: CGFloat = CGFloat(blue(for: pixel))  / 255


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates pixelColorAt() function to re-create the image in RGBA color space to fix issues and make more genetic

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#38 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a bug where incorrect colour was given for pixels within an image

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been run locally in BRC Emergency to make sure it works

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone Xs Max - 2019-09-26 at 09 56 03](https://user-images.githubusercontent.com/9033831/65674046-d7d4f800-e043-11e9-9171-31133c62bfd2.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.