### PR TITLE
Fixes image resizing method using incorrect size property

### DIFF
--- a/ThunderBasics/UIImage+Resize.swift
+++ b/ThunderBasics/UIImage+Resize.swift
@@ -90,8 +90,8 @@ extension UIImage {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         guard let context = CGContext(
             data: nil,
-            width: Int(size.width),
-            height: Int(size.height),
+            width: Int(newRect.size.width),
+            height: Int(newRect.size.height),
             bitsPerComponent: 8,
             bytesPerRow: Int(newRect.size.width * 4),
             space: colorSpace,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Swift re-write of image resizing was incorrectly using `image.size` when creating new graphics context, rather than `newRect.size`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes image resizing in ARC Emergency project

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested running locally in ARC Emergency

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
