### PR TITLE
Overrides backgroundColor prop on `MultipleShadowView` so it updates

### DIFF
--- a/ThunderBasics/MultipleShadowView.swift
+++ b/ThunderBasics/MultipleShadowView.swift
@@ -43,6 +43,14 @@ public class MultipleShadowView: UIView {
         return CornerObservableLayer.self
     }
     
+    public override var backgroundColor: UIColor? {
+        didSet {
+            forEachShadowLayer { (shadowLayer) in
+                shadowLayer.backgroundColor = layer.backgroundColor
+            }
+        }
+    }
+    
     /// Whether the shadow layers should update their corner radius to match the view's
     /// layer's corner radius
     public var matchShadowCornerRadius: Bool = true {


### PR DESCRIPTION
the shadow layer's background colour too

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue where changing view BG colour would not update because of the `CALayers` used by layer shadows

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in Blood

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
