### PR TITLE
Fixes compiling in Xcode 12

### DIFF
--- a/ThunderBasics/DesignableView.swift
+++ b/ThunderBasics/DesignableView.swift
@@ -77,11 +77,12 @@ public class ScaleBasedConstraint: NSLayoutConstraint {
     open override func prepareForInterfaceBuilder() {
         
         super.prepareForInterfaceBuilder()
+        // We don't set layer.shadowColor here because it clashes when compiling
+        // with `UILabel`'s own `shadowColor` property.
         layer.cornerRadius = cornerRadius
         layer.borderColor = borderColor?.cgColor
         layer.borderWidth = borderWidth
         layer.shadowRadius = shadowRadius
-        layer.shadowColor = shadowColor?.cgColor
         layer.shadowOpacity = shadowOpacity
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes sure `ThunderBasics` can compile in Xcode 12. Apple seem to have added a `shadowColor` property to `UILabel` which causes a compiler error in the line removed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to get the library compiling in Xcode 12!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in a personal project. It doesn't actually affect runtime at all

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
