### PR TITLE
Changes class to AnyObject

### DIFF
--- a/ThunderBasics/MultipleShadowView.swift
+++ b/ThunderBasics/MultipleShadowView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 
-protocol CornerObservableLayerDelegate: class {
+protocol CornerObservableLayerDelegate: AnyObject {
     
     func cornerObservableLayer(_ layer: CornerObservableLayer, didUpdateCornerRadius cornerRadius: CGFloat)
     


### PR DESCRIPTION
Fixed issue in Swift 5.4: changed 'class' to 'AnyObject' for protocol inheritance.